### PR TITLE
Adds start and stop buttons to area properties form

### DIFF
--- a/frontend/src/components/AreaPropertiesForm/index.css
+++ b/frontend/src/components/AreaPropertiesForm/index.css
@@ -10,7 +10,7 @@
 #area-properties-box{
     background-color: white;
     width: 80%;
-    padding-bottom: 5vh;
+    padding-bottom: 3vh;
     border-radius: 2vw;
 }
 
@@ -24,15 +24,15 @@
     font-size: 1vw;
 }
 
-#area-property-button{
+#calculate-route-button{
     width: 100%;
     display: flex;
     justify-content: center;
 }
 
-#area-property-button button{
+#calculate-route-button button{
     height: 8vh;
-    width: 70%;
+    width: 80%;
     background-color: white;
     color: #3DCBEB;
     border: none;
@@ -41,13 +41,35 @@
     font-size: 1vw;
 }
 
-#fa-icon-compass{
-    padding-right: 0.5vw;
-}
-
-#area-property-button button:hover{
+#calculate-route-button button:hover{
     background-color: #3DCBEB;
     color: white;
+}
+
+#start-stop-buttons{
+    width: 100%;
+    display: flex;
+    justify-content: center;
+}
+
+#start-stop-buttons button{
+    height: 8vh;
+    width: 40%;
+    background-color: white;
+    color: #3DCBEB;
+    border: none;
+    border-radius: 0.5vw;
+    cursor: pointer;
+    font-size: 1vw;
+}
+
+#start-stop-buttons button:hover{
+    background-color: #3DCBEB;
+    color: white;
+}
+
+#fa-icon-compass{
+    padding-right: 0.5vw;
 }
 
 #area-properites-box-title p{

--- a/frontend/src/components/AreaPropertiesForm/index.js
+++ b/frontend/src/components/AreaPropertiesForm/index.js
@@ -1,8 +1,27 @@
 import './index.css'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCompass } from '@fortawesome/free-solid-svg-icons'
+import api from '../../services/api'
 
 function AreaPropertiesForm(props) {
+
+    const setIrrigationStatus = value => {
+        api.post("/commands/irrigate", {
+            "irrigate": value
+        }).then(response => {
+            console.log(response)
+        }).catch(error => {
+            console.error(error)
+        })
+    }
+
+    const startIrrigation = () => {
+        setIrrigationStatus(true)
+    }
+
+    const stopIrrigation = () => {
+        setIrrigationStatus(false)
+    }
 
     return (
         <div id='area-properties'>
@@ -39,10 +58,10 @@ function AreaPropertiesForm(props) {
                         </button>
                     </div>
                     <div id="start-stop-buttons">
-                        <button id="">
+                        <button onClick={startIrrigation}>
                             Iniciar rota
                         </button>
-                        <button id="stop-route-button">
+                        <button onClick={stopIrrigation}>
                             Parar rota
                         </button>
                     </div>

--- a/frontend/src/components/AreaPropertiesForm/index.js
+++ b/frontend/src/components/AreaPropertiesForm/index.js
@@ -31,11 +31,21 @@ function AreaPropertiesForm(props) {
                         <option value="4">4</option>
                     </select>
                 </div>
-                <div id="area-property-button">
-                    <button>
-                        <FontAwesomeIcon id='fa-icon-compass' icon={faCompass}/>
-                        Calcular rota
-                    </button>
+                <div id="area-property-buttons">
+                    <div id="calculate-route-button">
+                        <button>
+                            <FontAwesomeIcon id='fa-icon-compass' icon={faCompass}/>
+                            Calcular rota
+                        </button>
+                    </div>
+                    <div id="start-stop-buttons">
+                        <button id="">
+                            Iniciar rota
+                        </button>
+                        <button id="stop-route-button">
+                            Parar rota
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This PR implements 2 new buttons in AreaPropertiesForm component: iniciar rota, parar rota

![image](https://user-images.githubusercontent.com/39436190/187926786-c2edb807-661b-418f-b0c4-7a6b6ed1296a.png)

Edit: the buttons are already integrated with backend endpoints